### PR TITLE
mac does not have --parents

### DIFF
--- a/run.pxi
+++ b/run.pxi
@@ -31,7 +31,7 @@
   (apply println "echo" args))
 
 (defn mkdir [dir]
-  (println "mkdir" "--parents" dir))
+  (println "mkdir" "-p" dir))
 
 (defn rm [file]
   (println "rm" file))


### PR DESCRIPTION
Running on a mac the mkdir --parents didn't work for me.

Other than that, everything else works great.

```
-> dust get-deps
Downloading heyLu/hiccup.pxi
```

```
-> dust repl
Pixie 0.1 - Interactive REPL
(darwin_x86_64, clang)
:exit-repl or Ctrl-D to quit
----------------------------
user => (use 'hiccup.core)
Warning: URLEncode already refers to <inst pixie.stdlib.Var>
Warning: *encoding* already refers to <inst pixie.stdlib.Var>
Warning: float already refers to <inst pixie.stdlib.Var>
Warning: ToURI already refers to <inst pixie.stdlib.Var>
Warning: *base-url* already refers to <inst pixie.stdlib.Var>
Warning: url-encode already refers to <inst pixie.stdlib.Var>
Warning: *html-mode* already refers to <inst pixie.stdlib.Var>
Warning: to-str already refers to <inst pixie.stdlib.Var>
Warning: url already refers to <inst pixie.stdlib.Var>
Warning: ToString already refers to <inst pixie.stdlib.Var>
Warning: with-encoding already refers to <inst pixie.stdlib.Var>
Warning: with-base-url already refers to <inst pixie.stdlib.Var>
Warning: escape-html already refers to <inst pixie.stdlib.Var>
Warning: as-str already refers to <inst pixie.stdlib.Var>
Warning: to-uri already refers to <inst pixie.stdlib.Var>
nil
user => (html [:span#foo.bar.baz "HOORAY!"])
"<span class="bar baz" id="foo">HOORAY!</span>"
```

```
-> dust run fairyland.pxi 
Warning: URLEncode already refers to <inst pixie.stdlib.Var>
Warning: *encoding* already refers to <inst pixie.stdlib.Var>
Warning: float already refers to <inst pixie.stdlib.Var>
Warning: ToURI already refers to <inst pixie.stdlib.Var>
Warning: *base-url* already refers to <inst pixie.stdlib.Var>
Warning: url-encode already refers to <inst pixie.stdlib.Var>
Warning: *html-mode* already refers to <inst pixie.stdlib.Var>
Warning: to-str already refers to <inst pixie.stdlib.Var>
Warning: url already refers to <inst pixie.stdlib.Var>
Warning: ToString already refers to <inst pixie.stdlib.Var>
Warning: with-encoding already refers to <inst pixie.stdlib.Var>
Warning: with-base-url already refers to <inst pixie.stdlib.Var>
Warning: escape-html already refers to <inst pixie.stdlib.Var>
Warning: as-str already refers to <inst pixie.stdlib.Var>
Warning: to-uri already refers to <inst pixie.stdlib.Var>
<span class="bar baz" id="foo">HOORAY!</span>
```
