### PR TITLE
Changed #! at top to support cross platform use.

### DIFF
--- a/dust
+++ b/dust
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 base_path=$0
 if [ -L "$base_path" ]; then


### PR DESCRIPTION
Some OSes (notably FreeBSD, but surely there are others) do not store bash in the same location as Linux or OSX. The cross-platform solution for this issue is generally to use the env command to properly locate it instead of calling it with a hard-coded path.