### PR TITLE
Alert user when 'pixie-vm' not on PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ user => @load-paths
 ## Installation
 
 * install [Pixie](https://github.com/pixie-lang/pixie)
+* `ln -s <path-to-pixie>/pixie-vm /usr/bin/pixie-vm` (or really anywhere else in `$PATH`)
 * `git clone git://github.com/pixie-lang/dust`
 * `ln -s <path-to-dust>/dust /usr/bin/dust` (or really anywhere else in `$PATH`)
 

--- a/dust
+++ b/dust
@@ -7,6 +7,10 @@ fi
 base_path=`dirname $base_path`
 
 pixie_path=`which pixie-vm`
+if [ -z "$pixie_path" ]; then
+    echo "Error: 'pixie-vm' must be on your PATH"
+    exit 1
+fi
 run_dust="$pixie_path -l $base_path/src $base_path/run.pxi"
 
 function load_path() {


### PR DESCRIPTION
The install instructions for pixie do not mention putting the executable on your PATH but this step is required to use `dust`.

Without a correct `$PATH`, you may see an error like:

```sh
dust: line 19: -l: command not found
Usage: rlwrap [options] command ...
```