### PR TITLE
Project as data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,15 @@ dependencies.
 
 ## Project definition
 
-`dust` reads its settings from a per-project `project.pxi` file. In that file
+`dust` reads its settings from a per-project `project.edn` file. In that file
 one configures the name, version, dependencies and other metadata about the
 project:
 
 ```clojure
-(defproject dust "0.1.0-alpha"
-  :description "Magic fairy dust for Pixie"
-  :dependencies [[heyLu/hiccup.pxi "0.1.0-alpha"]])
+{:name dust
+ :version "0.1.0-alpha"
+ :description "Magic fairy dust for Pixie"
+ :dependencies [[heyLu/hiccup.pxi "0.1.0-alpha"]]}
 ```
 
 With such a project definition you can run `dust get-deps` to fetch the

--- a/dust
+++ b/dust
@@ -20,6 +20,10 @@ function set_load_path() {
     fi
 }
 
+if [ ! -f "project.edn" ] && [ -f "project.pxi" ]; then
+	echo "Warning: 'project.pxi' is deprecated, please use 'project.edn'."
+fi
+
 case $1 in
     ""|"repl")
         rlwrap_cmd=""

--- a/dust
+++ b/dust
@@ -15,7 +15,7 @@ run_dust="$pixie_path -l $base_path/src $base_path/run.pxi"
 
 function set_load_path() {
     load_path=""
-    if [ -f "project.pxi" ] && [ -f ".load-path" ]; then
+    if ([ -f "project.edn" ] || [ -f "project.pxi" ]) && [ -f ".load-path" ]; then
         load_path="`cat .load-path`"
     fi
 }

--- a/dust
+++ b/dust
@@ -22,6 +22,9 @@ function set_load_path() {
 
 if [ ! -f "project.edn" ] && [ -f "project.pxi" ]; then
 	echo "Warning: 'project.pxi' is deprecated, please use 'project.edn'."
+	echo "To start you can run the following command:"
+	echo "  pixie-vm -l $base_path/src -e '(require dust.project :as p) (p/load-project!) (prn (dissoc @p/*project* :path))'"
+	echo
 fi
 
 case $1 in

--- a/project.edn
+++ b/project.edn
@@ -1,0 +1,4 @@
+{:name dust
+ :version "0.1.0-alpha"
+ :description "Magic fairy dust for Pixie"
+ :dependencies []}

--- a/run.pxi
+++ b/run.pxi
@@ -1,5 +1,5 @@
 (require dust.project :as p)
-(refer 'dust.project :only '(defproject))
+(refer 'dust.project :only '(defproject load-project!))
 
 (require dust.deps :as d)
 (require pixie.string :as str)
@@ -13,7 +13,7 @@
   [name description params & body]
   (let [body (if (:no-project (meta name))
                body
-               (cons `(load-file "project.pxi") body))
+               (cons `(load-project!) body))
         cmd {:name (str name)
              :description description
              :params `(quote ~params)

--- a/src/dust/deps.pxi
+++ b/src/dust/deps.pxi
@@ -32,16 +32,6 @@
     (io/spit ".load-path"
              (str "--load-path " (str/join " --load-path " paths)))))
 
-(defn load-project
-  "Load project.pxi in dir - return project map"
-  [dir]
-  (-> (io/slurp (str dir "/project.pxi"))
-      (read-string)
-      (rest)
-      (p/project->map)
-      (eval)
-      (assoc :path dir)))
-
 (defn resolve-dependency
   "Download and extract dependency - return dependency project map."
   [[name version]]
@@ -53,7 +43,7 @@
       (download url file-name)
       (extract-to file-name dep-dir)
       (rm file-name))
-    (load-project dep-dir)))
+    (p/read-project dep-dir)))
 
 (defn get-deps
   "Recursively download and extract all project dependencies."

--- a/src/dust/project.pxi
+++ b/src/dust/project.pxi
@@ -1,4 +1,5 @@
 (ns dust.project
+  (require pixie.io :as io)
   (require pixie.string :as str))
 
 (def *project* (atom nil))
@@ -23,6 +24,16 @@
         (assoc :name `(quote ~nm) :version version)
         quote-dependency-names
         merge-defaults)))
+
+(defn read-project
+  "Load project in dir, returning the project map"
+  [dir]
+  (-> (io/slurp (str dir "/project.pxi"))
+      (read-string)
+      (rest)
+      (project->map)
+      (eval)
+      (assoc project :path dir)))
 
 (defmacro defproject
   [& args]

--- a/src/dust/project.pxi
+++ b/src/dust/project.pxi
@@ -1,11 +1,12 @@
 (ns dust.project
+  (require pixie.fs :as fs)
   (require pixie.io :as io)
   (require pixie.string :as str))
 
 (def *project* (atom nil))
 
 (defn merge-defaults [project]
-  (merge {:source-paths ["src"]} project))
+  (merge {:source-paths ["src"], :dependencies []} project))
 
 (defn quote-dependency-names
   [project]
@@ -28,12 +29,19 @@
 (defn read-project
   "Load project in dir, returning the project map"
   [dir]
-  (-> (io/slurp (str dir "/project.pxi"))
-      (read-string)
-      (rest)
-      (project->map)
-      (eval)
-      (assoc project :path dir)))
+  (let [project (if (fs/exists? (fs/file (str dir "/project.edn")))
+                  (-> (io/slurp (str dir "/project.edn"))
+                      (read-string)
+                      (merge-defaults))
+                  (-> (io/slurp (str dir "/project.pxi"))
+                      (read-string)
+                      (rest)
+                      (project->map)
+                      (eval)))]
+    (assoc project :path dir)))
+
+(defn load-project! []
+  (reset! *project* (read-project ".")))
 
 (defmacro defproject
   [& args]


### PR DESCRIPTION
This adds support for reading the project definition from a `project.edn` file. It's very similar to our current `project.pxi`, but edn.

We warn the user and suggest a command to generate a `project.edn` from the `project.pxi` when we find a `project.pxi`, but no `project.edn`.

Project definitions using `project.edn` are preferred over the old ones.

This should handle #4.