### PR TITLE
Load path fix

### DIFF
--- a/src/dust/deps.pxi
+++ b/src/dust/deps.pxi
@@ -30,7 +30,7 @@
                           source-paths))
                       (:dependencies project))]
     (io/spit ".load-path"
-             (str "--load-path " (str/join " --load-path " paths)))))
+             (str/trim (str "--load-path " (str/join " --load-path " paths))))))
 
 (defn resolve-dependency
   "Download and extract dependency - return dependency project map."


### PR DESCRIPTION
The last path in `@load-paths`  has a `\r` return in it. This caused (on Ubuntu Linux) the last path to not be loaded.