### PR TITLE
Present error messages nicer

### DIFF
--- a/run.pxi
+++ b/run.pxi
@@ -108,5 +108,5 @@
     (if cmd
       (apply (get cmd :cmd) (next program-arguments))
       (println "Unknown command:" *command*))
-    (catch :dust/DustException e
+    (catch :dust/Exception e
       (println (str "Dust encountered an error: " (pr-str (ex-msg e)))))))

--- a/run.pxi
+++ b/run.pxi
@@ -85,7 +85,7 @@
         (println (str "Usage: dust " name " " params))
         (println)
         (println description))
-      (println "Unkown command:" cmd))))
+      (println "Unknown command:" cmd))))
 
 (defn help-all []
   (println "Usage: dust <cmd> <options>")
@@ -104,6 +104,9 @@
 (def *command* (first program-arguments))
 
 (let [cmd (get @*all-commands* (symbol *command*))]
-  (if cmd
-    (apply (get cmd :cmd) (next program-arguments))
-    (println "Unknown command:" *command*)))
+  (try
+    (if cmd
+      (apply (get cmd :cmd) (next program-arguments))
+      (println "Unknown command:" *command*))
+    (catch :dust/DustException e
+      (println (str "Dust encountered an error: " (pr-str (ex-msg e)))))))

--- a/src/dust/deps.pxi
+++ b/src/dust/deps.pxi
@@ -39,7 +39,7 @@
         _ (download url file-name)
         extraction-result (extract-to file-name dep-dir)]
     (when-not (zero? extraction-result)
-      (throw [:dust/DustException (str "Didn't find a valid tarball at " url)]))
+      (throw [:dust/Exception (str "Didn't find a valid tarball at " url)]))
     (rm file-name)))
 
 (defn resolve-dependency

--- a/src/dust/deps.pxi
+++ b/src/dust/deps.pxi
@@ -39,7 +39,7 @@
         _ (download url file-name)
         extraction-result (extract-to file-name dep-dir)]
     (when-not (zero? extraction-result)
-      (throw (str "Didn't find a valid tarball at " url)))
+      (throw [:dust/DustException (str "Didn't find a valid tarball at " url)]))
     (rm file-name)))
 
 (defn resolve-dependency

--- a/src/dust/project.pxi
+++ b/src/dust/project.pxi
@@ -40,7 +40,7 @@
                                        (rest)
                                        (project->map)
                                        (eval))
-          :else (throw [:dust/DustException "Dust did not find 'project.edn'"]))]
+          :else (throw [:dust/Exception "Dust did not find 'project.edn'"]))]
     (assoc project :path dir)))
 
 (defn load-project! []

--- a/src/dust/project.pxi
+++ b/src/dust/project.pxi
@@ -40,7 +40,7 @@
                                        (rest)
                                        (project->map)
                                        (eval))
-          :else (throw "Dust did not find 'project.edn'"))]
+          :else (throw [:dust/DustException "Dust did not find 'project.edn'"]))]
     (assoc project :path dir)))
 
 (defn load-project! []


### PR DESCRIPTION
I'm not sure what is preferred, but this makes errors displayed like:

```
$ dust get-deps
Dust encountered an error: "Dust did not find 'project.edn'"
```