### PR TITLE
Getting rid of old dust project.pxi file

### DIFF
--- a/project.pxi
+++ b/project.pxi
@@ -1,3 +1,0 @@
-(defproject dust "0.1.0-alpha"
-  :description "Magic fairy dust for Pixie"
-  :dependencies [])


### PR DESCRIPTION
Throws error when present:

```
Error:  in internal function load-file

in internal function load-reader

Running: (require dust.project :as p)
in /Users/jelle/dev/github/pixie/dust/run.pxi at 1:1
(require dust.project :as p)
^
in pixie function _toplevel_

in internal function load-ns

in internal function load-file

in internal function load-reader

Running: (defproject dust 0.1.0-alpha :description Magic fairy dust for Pixie :dependencies [])
in /Users/jelle/dev/github/pixie/dust/project.pxi at 1:1
(defproject dust "0.1.0-alpha"
^
in pixie function _toplevel_

in /Users/jelle/dev/github/pixie/dust/project.pxi at 1:2
(defproject dust "0.1.0-alpha"
 ^
RuntimeException: :pixie.stdlib/AssertionException Var defproject is undefined
```
