### PR TITLE
PR: dust documentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ dependencies.
     deps      List the dependencies and their versions of the current project.
     repl      Start a REPL in the current project.
     run       Run the code in the given file.
+    doc       Show function documentation. Broaden search using -all
     load-path Print the load path of the current project.
     test      Run the tests of the current project.
     help      Display the help

--- a/run.pxi
+++ b/run.pxi
@@ -89,7 +89,7 @@
           (reset! namespaces '())))))
 
 (defcmd doc
-  "Show function documentation. Broad search using -all"
+  "Show function documentation. Broaden search using -all"
   [function-name & search-all]
   (if (= (str (first search-all)) "-all") (reset! show-all true))
   (loop [_ 0]

--- a/run.pxi
+++ b/run.pxi
@@ -12,32 +12,7 @@
 (def *all-commands* (atom {}))
 (def unknown-command (atom true))
 (def show-all (atom false))
-(def namespaces (atom 
-  '("" 
-    "pixie.async"
-    "pixie.math"
-    "pixie.stacklets"
-    "pixie.system"
-    "pixie.buffers"
-    "pixie.test"
-    "pixie.channels"
-    "pixie.parser"
-    "pixie.time"
-    "pixie.csp"
-    "pixie.uv"
-    "pixie.repl"
-    "pixie.streams"
-    "pixie.ffi-infer"
-    "pixie.io.common"
-    "pixie.io.tty"
-    "pixie.io.tcp"
-    "pixie.io.uv-common"
-    "pixie.io"
-    "pixie.io-blocking"
-    "pixie.fs"
-    "pixie.set"
-    "pixie.string"
-    "pixie.walk")))
+(def namespaces (atom '(""  "pixie.async" "pixie.math" "pixie.stacklets" "pixie.system" "pixie.buffers" "pixie.test" "pixie.channels" "pixie.parser" "pixie.time" "pixie.csp" "pixie.uv" "pixie.repl" "pixie.streams" "pixie.ffi-infer" "pixie.io.common" "pixie.io.tty" "pixie.io.tcp" "pixie.io.uv-common" "pixie.io" "pixie.io-blocking" "pixie.fs" "pixie.set" "pixie.string" "pixie.walk")))
 
 
 (defmacro defcmd
@@ -57,36 +32,32 @@
   []
   (p/describe @p/*project*))
 
-(defn loadns [ns]
-  ;(print (str "(require " ns ")"))  
-  (eval (read-string (str "(require " ns ")"))))
 
 (defn showdoc [ns function]
-  
+  (let [name (str (if (not= ns "") (str ns "/") ""))]
   ;loads other possible namespaces in case function is in other namespace
-  (def name (str (if (not= ns "") (str ns "/") "")))
-  (if (= @show-all true) (loadns ns))
-    
-  (def data (meta (eval (read-string (str name function)))))
-    (if (nil? data)
-      (#(%) 
-        (println (str "\n  " name function "\n\n\t No documentation available.\n"))
-        (reset! unknown-command false)
-        (if (= (first @namespaces) "") (reset! namespaces '())))
-      (#(%)
-        (print (str "\n  " name function)) 
-        (print 
-          (if (not= (str (:added data)) "nil") 
-              (str " (added: v" (:added data) ")") 
-              (str ""))) 
-        (print (str "\n\n\t"))
-        (println
-          (if (not= (str (:doc data)) "nil") 
-              (str (:doc data) "\n")
-              (str "No documentation available.\n"))) 
-        (reset! unknown-command false)
-        (if (= (first @namespaces) "")
-          (reset! namespaces '())))))
+    (if (= @show-all true) (eval (read-string (str "(require " ns ")"))))
+      
+    (def data (meta (eval (read-string (str name function)))))
+      (if (nil? data)
+        (#(%) 
+          (println (str "\n  " name function "\n\n\t No documentation available.\n"))
+          (reset! unknown-command false)
+          (if (= (first @namespaces) "") (reset! namespaces '())))
+        (#(%)
+          (print (str "\n  " name function)) 
+          (print 
+            (if (not= (str (:added data)) "nil") 
+                (str " (added: v" (:added data) ")") 
+                (str ""))) 
+          (print (str "\n\n\t"))
+          (println
+            (if (not= (str (:doc data)) "nil") 
+                (str (:doc data) "\n")
+                (str "No documentation available.\n"))) 
+          (reset! unknown-command false)
+          (if (= (first @namespaces) "")
+            (reset! namespaces '()))))))
 
 (defcmd doc
   "Show function documentation. Broaden search using -all"

--- a/run.pxi
+++ b/run.pxi
@@ -38,7 +38,7 @@
   ;loads other possible namespaces in case function is in other namespace
     (if (= @show-all true) (eval (read-string (str "(require " ns ")"))))
       
-    (def data (meta (eval (read-string (str name function)))))
+    (let [data (meta (eval (read-string (str name function))))]
       (if (nil? data)
         (#(%) 
           (println (str "\n  " name function "\n\n\t No documentation available.\n"))
@@ -57,7 +57,7 @@
                 (str "No documentation available.\n"))) 
           (reset! unknown-command false)
           (if (= (first @namespaces) "")
-            (reset! namespaces '()))))))
+            (reset! namespaces '())))))))
 
 (defcmd doc
   "Show function documentation. Broaden search using -all"


### PR DESCRIPTION
Added `doc` command to `dust`

dust doc has two useages:
* Usage 1 only searches the namespaces loaded into dust: stdlib, io, fs, io
* Usage 2 searches loads and searches all namespaces (namespaces have to be added manually to source at the moment). All occurrences of the function are shown except if the function is present in stdlib.

Usage 1: dust doc <function name>
```
$dust doc chan

chan

	 Function not found. Broaden search using -all flag.

$
```
Usage 2: dust doc <function name> -all
```
$dust doc chan -all

pixie.channels/chan

	Creates a CSP channel with the given buffer. If an integer is provided as the argument
   creates a channel with a fixed buffer of that size. 


  pixie.csp/chan

	Creates a CSP channel with the given buffer. If an integer is provided as the argument
   creates a channel with a fixed buffer of that size. 

$
```